### PR TITLE
Add missing double-quote in example Json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Short example:
       "item": "Integrations",
       "href": "/config/integrations",
       "icon": "mdi:puzzle",
-      "order: 3
+      "order": 3
     }
   ]
  }


### PR DESCRIPTION
There's a missing double quote that, if the user decides to copy the example out as a starting point to play with, will cause the custom sidebar not to work; this just fixes that