### PR TITLE
Fix Non-Admin issue in getSidebarItem

### DIFF
--- a/dist/custom-sidebar-v2.js
+++ b/dist/custom-sidebar-v2.js
@@ -140,11 +140,20 @@
     if (!root || !root.children) {
       return;
     }
-    return Array.from(root.children).find((element) => {
+    let lastdatapanel = Array.from(root.children).find((element) => {
       return (
         element.tagName == 'A' && element.getAttribute('data-panel') == 'config'
       );
     });
+    if (!lastdatapanel) {
+      lastpanel = Array.from(root.children).find((element) => {
+        return (
+          element.tagName == 'A' && element.getAttribute('data-panel') == 'media-browser'
+        );
+      });
+    }
+      
+    return lastpanel;
   }
 
   function setTitle(title) {


### PR DESCRIPTION
Fixing issue highlighted in #12 where non-admin users do not have a config data-panel. If undefined it will instead use media-browser as the last element.